### PR TITLE
Add flag prometheus.web.config.file

### DIFF
--- a/cmd/promxy/main.go
+++ b/cmd/promxy/main.go
@@ -83,9 +83,10 @@ type cliOpts struct {
 	LogFormat        string `long:"log-format" description:"Log format(text|json)" default:"text"`
 	LogMaxFormPrefix int    `long:"log-max-form-prefix" description:"Max prefix for form values in log entries" default:"256"`
 
-	WebConfigFile      string        `long:"web.config.file" description:"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication."`
-	WebCORSOriginRegex string        `long:"web.cors.origin" description:"Regex for CORS origin. It is fully anchored." default:".*"`
-	WebReadTimeout     time.Duration `long:"web.read-timeout" description:"Maximum duration before timing out read of the request, and closing idle connections." default:"5m"`
+	WebConfigFile           string        `long:"web.config.file" description:"[EXPERIMENTAL] Path to configuration file that can enable TLS or authentication. This flag will be ignored if prometheus.web.config.file is used."`
+	PrometheusWebConfigFile string        `long:"prometheus.web.config.file" description:"[EXPERIMENTAL] Path to prometheus web configuration file that can enable TLS or authentication."`
+	WebCORSOriginRegex      string        `long:"web.cors.origin" description:"Regex for CORS origin. It is fully anchored." default:".*"`
+	WebReadTimeout          time.Duration `long:"web.read-timeout" description:"Maximum duration before timing out read of the request, and closing idle connections." default:"5m"`
 
 	MetricsPath  string   `long:"metrics-path" description:"URL path for the prometheus metrics endpoint." default:"/metrics"`
 	ProxyHeaders []string `long:"proxy-headers" env:"PROXY_HEADERS" description:"a list of headers to proxy to downstream servergroups."`
@@ -487,7 +488,7 @@ func main() {
 		logrus.Fatalf("Invalid AccessLogDestination: %s", opts.AccessLogDestination)
 	}
 
-	srv, err := server.CreateAndStart(opts.BindAddr, opts.LogFormat, opts.WebReadTimeout, accessLogOut, middleware.NewProxyHeaders(r, opts.ProxyHeaders), opts.WebConfigFile)
+	srv, err := server.CreateAndStart(opts.BindAddr, opts.LogFormat, opts.WebReadTimeout, accessLogOut, middleware.NewProxyHeaders(r, opts.ProxyHeaders), server.WebConfigFile{TlsConfigFile: opts.WebConfigFile, WebConfigFile: opts.PrometheusWebConfigFile})
 	if err != nil {
 		logrus.Fatalf("Error creating server: %v", err)
 	}

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/prometheus/exporter-toolkit/web"
@@ -15,7 +16,27 @@ import (
 	"github.com/jacksontj/promxy/pkg/logging"
 )
 
-func CreateAndStart(bindAddr string, logFormat string, webReadTimeout time.Duration, accessLogOut io.Writer, router http.Handler, tlsConfigFile string) (*http.Server, error) {
+type WebConfigFile struct {
+	TlsConfigFile string
+	WebConfigFile string
+}
+
+func (f *WebConfigFile) isSet() bool {
+	return f.TlsConfigFile != "" || f.WebConfigFile != ""
+}
+
+func (f *WebConfigFile) useWebConfig() bool {
+	return f.WebConfigFile != ""
+}
+
+func hasTLSConfig(c *web.TLSStruct) bool {
+	if c.TLSCertPath == "" && c.TLSKeyPath == "" && c.ClientAuth == "" && c.ClientCAs == "" {
+		return false
+	}
+	return true
+}
+
+func CreateAndStart(bindAddr string, logFormat string, webReadTimeout time.Duration, accessLogOut io.Writer, router http.Handler, webConfigFile WebConfigFile) (*http.Server, error) {
 	handler := createHandler(accessLogOut, router, logFormat)
 
 	ln, err := net.Listen("tcp", bindAddr)
@@ -28,11 +49,19 @@ func CreateAndStart(bindAddr string, logFormat string, webReadTimeout time.Durat
 		ReadTimeout: webReadTimeout,
 	}
 
-	if tlsConfigFile == "" {
-		return createAndStartHTTP(srv, ln)
+	var webConfig *web.Config
+	if webConfigFile.useWebConfig() {
+		webConfig, err = parseWebConfigFile(webConfigFile.WebConfigFile)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	return createAndStartHTTPS(srv, ln, tlsConfigFile)
+	if !webConfigFile.isSet() || webConfigFile.useWebConfig() && !hasTLSConfig(&webConfig.TLSConfig) {
+		return createAndStartHTTP(srv, ln, webConfigFile)
+	}
+
+	return createAndStartHTTPS(srv, ln, webConfigFile)
 }
 
 func createHandler(accessLogOut io.Writer, router http.Handler, logFormat string) http.Handler {
@@ -51,12 +80,19 @@ func createHandler(accessLogOut io.Writer, router http.Handler, logFormat string
 	return handler
 }
 
-func createAndStartHTTP(srv *http.Server, ln net.Listener) (*http.Server, error) {
+func createAndStartHTTP(srv *http.Server, ln net.Listener, webConfigFile WebConfigFile) (*http.Server, error) {
 	srv.TLSConfig = nil
 
 	go func() {
 		logrus.Infof("promxy starting with HTTP...")
-		if err := srv.Serve(ln); err != nil {
+		var err error
+		if webConfigFile.useWebConfig() {
+			logger := logging.NewLogger(logrus.StandardLogger())
+			err = web.Serve(ln, srv, webConfigFile.WebConfigFile, logger)
+		} else {
+			err = srv.Serve(ln)
+		}
+		if err != nil {
 			if err == http.ErrServerClosed {
 				return
 			}
@@ -66,17 +102,24 @@ func createAndStartHTTP(srv *http.Server, ln net.Listener) (*http.Server, error)
 	return srv, nil
 }
 
-func createAndStartHTTPS(srv *http.Server, ln net.Listener, tlsConfigFile string) (*http.Server, error) {
-	tlsConfig, err := parseConfigFile(tlsConfigFile)
+func createAndStartHTTPS(srv *http.Server, ln net.Listener, webConfigFile WebConfigFile) (*http.Server, error) {
+	// Validate the config and get tlsConfig from it
+	tlsConfig, err := parseConfigFile(webConfigFile)
 	if err != nil {
 		return nil, err
 	}
 
-	srv.TLSConfig = tlsConfig
-
 	go func() {
 		logrus.Infof("promxy starting with TLS...")
-		if err := srv.ServeTLS(ln, "", ""); err != nil {
+		var err error
+		if webConfigFile.useWebConfig() {
+			logger := logging.NewLogger(logrus.StandardLogger())
+			err = web.Serve(ln, srv, webConfigFile.WebConfigFile, logger)
+		} else {
+			srv.TLSConfig = tlsConfig
+			err = srv.ServeTLS(ln, "", "")
+		}
+		if err != nil {
 			if err == http.ErrServerClosed {
 				return
 			}
@@ -86,7 +129,24 @@ func createAndStartHTTPS(srv *http.Server, ln net.Listener, tlsConfigFile string
 	return srv, nil
 }
 
-func parseConfigFile(tlsConfigFile string) (*tls.Config, error) {
+func parseConfigFile(webConfigFile WebConfigFile) (*tls.Config, error) {
+	if webConfigFile.useWebConfig() {
+		webConfig, err := parseWebConfigFile(webConfigFile.WebConfigFile)
+		if err != nil {
+			return nil, err
+		}
+		tlsConfig, err := web.ConfigToTLSConfig(&webConfig.TLSConfig)
+		if err != nil {
+			return nil, err
+		}
+
+		return tlsConfig, err
+	} else {
+		return parseTlsConfigFile(webConfigFile.TlsConfigFile)
+	}
+}
+
+func parseTlsConfigFile(tlsConfigFile string) (*tls.Config, error) {
 	content, err := os.ReadFile(tlsConfigFile)
 	if err != nil {
 		return nil, err
@@ -107,4 +167,25 @@ func parseConfigFile(tlsConfigFile string) (*tls.Config, error) {
 	}
 
 	return tlsConfig, err
+}
+
+func parseWebConfigFile(webConfigFile string) (*web.Config, error) {
+	content, err := os.ReadFile(webConfigFile)
+	if err != nil {
+		return nil, err
+	}
+	webConfig := &web.Config{
+		TLSConfig: web.TLSStruct{
+			MinVersion:               tls.VersionTLS12,
+			MaxVersion:               tls.VersionTLS13,
+			PreferServerCipherSuites: true,
+		},
+	}
+	err = yaml.UnmarshalStrict(content, webConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	webConfig.TLSConfig.SetDirectory(filepath.Dir(webConfigFile))
+	return webConfig, err
 }

--- a/pkg/server/api_test.go
+++ b/pkg/server/api_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -25,7 +26,7 @@ func TestUnauthenticatedServerFunctions(t *testing.T) {
 	router := httprouter.New()
 	router.HandlerFunc("GET", "/metrics", promhttp.Handler().ServeHTTP)
 
-	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, "")
+	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, WebConfigFile{"", ""})
 	if err != nil {
 		t.Fatalf("an error occurred during creation of server: %s", err.Error())
 	}
@@ -55,6 +56,55 @@ func TestUnauthenticatedServerFunctions(t *testing.T) {
 	server.Close()
 }
 
+func TestUnauthenticatedServerFunctionsWithWebConfig(t *testing.T) {
+	freePort, err := getFreePort()
+	if err != nil {
+		t.Fatalf("could not get a free port to run test: %s", err.Error())
+	}
+	bindAddr := fmt.Sprintf("localhost:%d", freePort)
+	router := httprouter.New()
+	router.HandlerFunc("GET", "/metrics", promhttp.Handler().ServeHTTP)
+
+	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, WebConfigFile{"", "testdata/http-server-config.yml"})
+	if err != nil {
+		t.Fatalf("an error occurred during creation of server: %s", err.Error())
+	}
+
+	client := &http.Client{
+		Transport: &http.Transport{},
+	}
+
+	time.Sleep(time.Millisecond * 5)
+	resp, err := client.Get(fmt.Sprintf("http://%s/metrics", bindAddr))
+	if err != nil {
+		t.Fatalf("could not make request to metrics endpoint: %s", err.Error())
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("could not read response body: %s", err.Error())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("an unexpected error occurred: unauthenticed client was unable to make a request to the unauthenticated server. Response body: %s", body)
+	}
+
+	if !strings.Contains(string(body), "go_goroutines") {
+		t.Fatalf("could not find metric name 'go_goroutines' in response")
+	}
+
+	expectedHeaders := http.Header{
+		"Content-Security-Policy": {"default-src 'self';"},
+		"X-Frame-Options":         {"sameorigin"},
+	}
+
+	if !headerContains(resp.Header, expectedHeaders) {
+		t.Fatalf("could not find expected headers in response, expected: %v, but received: %v.", expectedHeaders, resp.Header)
+	}
+
+	server.Close()
+}
+
 func TestAuthenticatedServerDoesNotStartupWithInvalidConfig(t *testing.T) {
 	freePort, err := getFreePort()
 	if err != nil {
@@ -64,9 +114,19 @@ func TestAuthenticatedServerDoesNotStartupWithInvalidConfig(t *testing.T) {
 	router := httprouter.New()
 	router.HandlerFunc("GET", "/metrics", promhttp.Handler().ServeHTTP)
 
-	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, "testdata/invalid-tls-server-config.yml")
+	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, WebConfigFile{"testdata/invalid-tls-server-config.yml", ""})
 	if err == nil {
 		t.Fatalf("server validated an invalid tlsConfig")
+	}
+
+	if server != nil {
+		server.Close()
+	}
+
+	// Test web server config
+	server, err = CreateAndStart(bindAddr, "text", time.Second*5, nil, router, WebConfigFile{"", "testdata/invalid-web-server-config.yml"})
+	if err == nil {
+		t.Fatalf("server validated an invalid webConfig")
 	}
 
 	if server != nil {
@@ -83,9 +143,9 @@ func TestMutualTLSClientCannotConnectToAuthenticatedServerWithoutCerts(t *testin
 	router := httprouter.New()
 	router.HandlerFunc("GET", "/metrics", promhttp.Handler().ServeHTTP)
 
-	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, "testdata/tls-server-config.yml")
+	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, WebConfigFile{"testdata/tls-server-config.yml", ""})
 	if err != nil {
-		t.Fatalf("an error occurred during creation of server: %s", err.Error())
+		t.Fatalf("an error occurred during creation of server using tlsConfig: %s", err.Error())
 	}
 
 	client := &http.Client{
@@ -102,6 +162,18 @@ func TestMutualTLSClientCannotConnectToAuthenticatedServerWithoutCerts(t *testin
 	}
 
 	server.Close()
+
+	// Test web server config
+	server, err = CreateAndStart(bindAddr, "text", time.Second*5, nil, router, WebConfigFile{"", "testdata/web-server-config.yml"})
+	if err != nil {
+		t.Fatalf("an error occurred during creation of server using webConfig: %s", err.Error())
+	}
+
+	_, err = client.Get(fmt.Sprintf("https://%s/metrics", bindAddr))
+	if err == nil {
+		t.Fatalf("was able to make a request to metrics endpoint when it should no have: %s", err.Error())
+	}
+	server.Close()
 }
 
 func TestMutualTLSClientCanConnectToAuthenticatedServerWithCerts(t *testing.T) {
@@ -113,9 +185,9 @@ func TestMutualTLSClientCanConnectToAuthenticatedServerWithCerts(t *testing.T) {
 	router := httprouter.New()
 	router.HandlerFunc("GET", "/metrics", promhttp.Handler().ServeHTTP)
 
-	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, "testdata/tls-server-config.yml")
+	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, WebConfigFile{"testdata/tls-server-config.yml", ""})
 	if err != nil {
-		t.Fatalf("an error occurred during creation of server: %s", err.Error())
+		t.Fatalf("an error occurred during creation of server using tlsConfig: %s", err.Error())
 	}
 
 	client := setupAuthenticatedClient(t)
@@ -138,6 +210,68 @@ func TestMutualTLSClientCanConnectToAuthenticatedServerWithCerts(t *testing.T) {
 		t.Fatalf("could not find metric name 'go_goroutines' in response")
 	}
 	server.Close()
+}
+
+func TestMutualTLSClientCanConnectToAuthenticatedServerWithWebConfig(t *testing.T) {
+	freePort, err := getFreePort()
+	if err != nil {
+		t.Fatalf("could not get a free port to run test: %s", err.Error())
+	}
+	bindAddr := fmt.Sprintf("localhost:%d", freePort)
+	router := httprouter.New()
+	router.HandlerFunc("GET", "/metrics", promhttp.Handler().ServeHTTP)
+
+	server, err := CreateAndStart(bindAddr, "text", time.Second*5, nil, router, WebConfigFile{"", "testdata/web-server-config.yml"})
+	if err != nil {
+		t.Fatalf("an error occurred during creation of server using webConfig: %s", err.Error())
+	}
+
+	client := setupAuthenticatedClient(t)
+	resp, err := client.Get(fmt.Sprintf("https://%s/metrics", bindAddr))
+	if err != nil {
+		t.Fatalf("could not make request to metrics endpoint: %s", err.Error())
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("could not read response body: %s", err.Error())
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("authenticated client was unable to make a request to the authenticated server. Response body: %s", body)
+	}
+
+	if !strings.Contains(string(body), "go_goroutines") {
+		t.Fatalf("could not find metric name 'go_goroutines' in response")
+	}
+
+	expectedHeaders := http.Header{
+		"Content-Security-Policy": {"default-src 'self';"},
+		"X-Frame-Options":         {"sameorigin"},
+	}
+
+	if !headerContains(resp.Header, expectedHeaders) {
+		t.Fatalf("could not find expected headers in response, expected: %v, but received: %v.", expectedHeaders, resp.Header)
+	}
+
+	server.Close()
+
+}
+
+func headerContains(header http.Header, expectedHeader http.Header) bool {
+	for expectedKey, expectedValues := range expectedHeader {
+		headerValues, ok := header[expectedKey]
+		if !ok {
+			return false
+		}
+
+		for _, expectedValue := range expectedValues {
+			if !slices.Contains(headerValues, expectedValue) {
+				return false
+			}
+		}
+	}
+	return true
 }
 
 func getFreePort() (int, error) {

--- a/pkg/server/testdata/http-server-config.yml
+++ b/pkg/server/testdata/http-server-config.yml
@@ -1,0 +1,4 @@
+http_server_config:
+  headers:
+    Content-Security-Policy: "default-src 'self';"
+    X-Frame-Options: "sameorigin"

--- a/pkg/server/testdata/invalid-web-server-config.yml
+++ b/pkg/server/testdata/invalid-web-server-config.yml
@@ -1,0 +1,5 @@
+tls_server_config:
+  cert_file: ""
+  key_file: ""
+  client_auth_type: "RequireAndVerifyClientCert"
+  client_ca_file: "testdata/test-ca.crt"

--- a/pkg/server/testdata/web-server-config.yml
+++ b/pkg/server/testdata/web-server-config.yml
@@ -1,0 +1,9 @@
+tls_server_config:
+  cert_file: "../../server/testdata/server.crt"
+  key_file: "../../server/testdata/server.key"
+  client_auth_type: "RequireAndVerifyClientCert"
+  client_ca_file: "../../server/testdata/test-ca.crt"
+http_server_config:
+  headers:
+    Content-Security-Policy: "default-src 'self';"
+    X-Frame-Options: "sameorigin"


### PR DESCRIPTION
Current web.config.file does not use the
same format as prometheus web.config.file.
It is also lacking http headers and basic
authentication handling.
This is to add prometheus.web.config.file
flag that works just like web.config.file
of prometheus. It allows configuring http
headers, while keeping the old flag
web.config.file for backward compatibility.